### PR TITLE
remove cursive from dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ regex = "0.2"
 lazy_static = "0.2.5"
 
 [dev-dependencies]
-cursive = "0.3.7"
 unicode-width = "0.1.4"
 
 [dependencies.xmpp-proto]


### PR DESCRIPTION
I just tried to compile the lib and then it failed because of cursive/ncurses but they aren't used anywhere so I think we can remove it ;-)
```
error: failed to run custom build command for `ncurses v5.85.0`
process didn't exit successfully: `/home/mk/dev/xmpp-rs/target/debug/build/ncurses-d7f72f0b9fc23b7f/build-script-build` (exit code: 101)
```